### PR TITLE
Fix Railway deployment: Enable web interface in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN echo '[supervisord]' > /etc/supervisord.conf && \
     echo 'autorestart=true' >> /etc/supervisord.conf && \
     echo 'stderr_logfile=/var/log/supervisor/mcp-server.err.log' >> /etc/supervisord.conf && \
     echo 'stdout_logfile=/var/log/supervisor/mcp-server.out.log' >> /etc/supervisord.conf && \
-    echo 'environment=PORT=%(ENV_PORT)s,NODE_ENV=production,REDIS_URL=redis://localhost:6379,MCP_TRANSPORT=sse' >> /etc/supervisord.conf
+    echo 'environment=PORT=%(ENV_PORT)s,NODE_ENV=production,WEB_INTERFACE=true,REDIS_URL=redis://localhost:6379,MCP_TRANSPORT=sse' >> /etc/supervisord.conf
 
 # Create startup script
 RUN echo '#!/bin/bash' > /start.sh && \
@@ -116,6 +116,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
 
 # Environment variables for local execution
 ENV NODE_ENV=production \
+    WEB_INTERFACE=true \
     MCP_TRANSPORT=sse \
     HOST=0.0.0.0 \
     REDIS_URL=redis://localhost:6379 \
@@ -124,6 +125,6 @@ ENV NODE_ENV=production \
     JAVA_HOME=/usr/lib/jvm/java-17-openjdk \
     GOPATH=/usr/local/go
 
-EXPOSE $PORT
+EXPOSE 3000
 
 CMD ["/start.sh"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ railway init
 railway up
 ```
 
+**Important**: Railway will automatically expose the web interface on the assigned port. The application includes:
+- Main web UI with documentation and configuration
+- Health endpoints for monitoring
+- SSE transport for MCP connections
+- Redis for session management (internal only)
+
 ### Using Docker (Local Development)
 
 ```bash

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -451,11 +451,16 @@ async function main(): Promise<void> {
       process.exit(1);
     });
 
-    // Start web interface if in development or web mode
-    const useWebInterface = process.env.NODE_ENV === 'development' || process.env.WEB_INTERFACE === 'true';
+    // Start web interface if in development, web mode, or Railway deployment
+    const isRailwayDeployment = process.env.RAILWAY_ENVIRONMENT || process.env.PORT;
+    const useWebInterface = process.env.NODE_ENV === 'development' || 
+                           process.env.WEB_INTERFACE === 'true' || 
+                           isRailwayDeployment;
+    
     if (useWebInterface) {
       const port = parseInt(process.env.PORT || '3000');
       await startWebInterface(port);
+      logger.info(`📚 Web interface started on port ${port}`);
       logger.info(`📚 Documentation: http://localhost:${port}`);
     }
 

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -12,4 +12,5 @@ cmd = "npm start"
 
 [variables]
 NODE_ENV = "production"
+WEB_INTERFACE = "true"
 MCP_TRANSPORT = "sse"

--- a/railway.toml
+++ b/railway.toml
@@ -7,4 +7,5 @@ restartPolicyMaxRetries = 3
 
 [env]
 NODE_ENV = "production"
+WEB_INTERFACE = "true"
 MCP_TRANSPORT = "sse"


### PR DESCRIPTION
## Problem
When deploying to Railway, only the Redis port (6379) was being exposed instead of the main web interface. This made the application inaccessible via the web URL that Railway provides.

## Root Cause
The web interface was only starting in development mode (`NODE_ENV === 'development'`) or when `WEB_INTERFACE === 'true'`. In production deployments on Railway, neither condition was met, so the web interface never started.

## Solution
This PR fixes the Railway deployment issue by:

1. **Auto-detecting Railway deployments**: Added logic to detect Railway environment and automatically start the web interface
2. **Setting WEB_INTERFACE=true**: Added the environment variable in all deployment configurations
3. **Proper port configuration**: Ensured the application uses Railway's assigned PORT environment variable
4. **Updated documentation**: Added notes about Railway deployment behavior

## Changes Made

### Code Changes
- **`mcp-server/src/index.ts`**: Updated startup logic to detect Railway deployments and start web interface
- **`Dockerfile`**: Added `WEB_INTERFACE=true` environment variable
- **`railway.toml`**: Added `WEB_INTERFACE=true` to environment configuration
- **`nixpacks.toml`**: Added `WEB_INTERFACE=true` to variables
- **`README.md`**: Added Railway deployment notes

### Technical Details
- The web interface now starts automatically when `RAILWAY_ENVIRONMENT` or `PORT` environment variables are detected
- Railway will now expose the main web interface (port 3000 or assigned PORT) instead of just Redis
- Redis remains internal for session management
- All existing functionality is preserved

## Testing
- ✅ Web interface starts in development mode
- ✅ Web interface starts in production with WEB_INTERFACE=true
- ✅ Web interface auto-starts on Railway deployments
- ✅ Health endpoints accessible
- ✅ SSE transport working for MCP connections

## Deployment Impact
After this fix, Railway deployments will:
- Expose the main web interface with documentation
- Provide access to health endpoints for monitoring
- Enable SSE transport for MCP connections
- Keep Redis internal for session management

This resolves the issue where users could only access the Redis port instead of the main application UI.